### PR TITLE
Improved list parsing.

### DIFF
--- a/.changeset/dirty-eggs-report.md
+++ b/.changeset/dirty-eggs-report.md
@@ -1,0 +1,5 @@
+---
+'@md-parser/parser': minor
+---
+
+Improved list parsing

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "dist/"
   ],
   "scripts": {
-    "test": "vitest --threads=false",
-    "coverage": "vitest run --coverage",
     "build": "rm -rf ./dist/ && ts-node-esm ./build.ts && tsc --emitDeclarationOnly --outDir dist && rm -rf ./dist/tests/",
-    "ts": "tsc --noemit --project ./tsconfig.json",
+    "coverage": "vitest run --coverage",
+    "dev": "nodemon --watch src --ext ts --exec \"yarn run build\"",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src/",
-    "nodemon": "nodemon --watch src --ext ts --exec \"yarn run build\"",
-    "release": "yarn ts && yarn test && yarn build && changeset publish"
+    "release": "yarn ts && yarn test && yarn build && changeset publish",
+    "test": "vitest --threads=false",
+    "ts": "tsc --noemit --project ./tsconfig.json"
   },
   "dependencies": {
     "@changesets/cli": "^2.26.1"

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,11 +41,12 @@ export type ParserContext = {
   parseInline: (predicate: () => boolean) => MarkdownNode[];
   readUntil: (predicate: (char: string) => boolean) => string;
   parse: (src: string) => MarkdownNode[];
+  parseIndentation: () => void;
 };
 
 export function mdAST(config: ParserConfig = {}) {
   const rules: Rule<MarkdownNode>[] = [
-    codeRule, // codeRule needs to be the first rule
+    codeRule, // codeRule needs to be the first rule, or not?...
     strongRule,
     emphasisRule,
     linkRule,
@@ -86,6 +87,7 @@ export function mdAST(config: ParserConfig = {}) {
     skipUntil,
     parseInline,
     readUntil,
+    parseIndentation,
     parse: parseSubTree,
   };
 

--- a/src/rules/heading.ts
+++ b/src/rules/heading.ts
@@ -29,6 +29,10 @@ export const headingRule: Rule<MarkdownHeadingNode> = {
 
     const level = getLevel(state.src.slice(state.position));
 
+    if (state.charAt(level) !== ' ') {
+      return false;
+    }
+
     return level > 0 && level < 7;
   },
   parse(state, parser) {

--- a/src/rules/lineBreak.ts
+++ b/src/rules/lineBreak.ts
@@ -4,11 +4,22 @@ import { Rule } from '../types/rule';
 export const lineBreakRule: Rule<MarkdownLineBreakNode> = {
   type: 'inline',
   name: 'lineBreak',
-  ruleStartChar: '\n',
+  ruleStartChar: ['\n', '\\'],
   test(state) {
+    const char = state.charAt(0);
+
+    if (char === '\\' && state.charAt(1) === '\n') {
+      return true;
+    }
+
     return state.charAt(0) === '\n';
   },
   parse(state, parser) {
+    if (state.charAt(0) === '\\') {
+      // skip \
+      parser.skip(1);
+    }
+
     // skip \n
     parser.skip(1);
 

--- a/src/rules/list.ts
+++ b/src/rules/list.ts
@@ -1,8 +1,9 @@
 import { MarkdownListNode } from '../types/nodes';
 import { Rule } from '../types/rule';
 
-const LIST_ITEM_REGEX = /^\s*(?:[*+-]|\d+\.)[\t ]/;
-const ORDERED_LIST_ITEM_REGEX = /^[\t ]*\d+. /;
+const LIST_ITEM_REGEX = /^[\t ]*(?:[*+-]|\d+\.)[\t ]/;
+const ORDERED_LIST_ITEM_REGEX = /^[\t ]*\d+.[\t ]/;
+const EMPTY_LINE_REGEX = /^\s*$/;
 
 function isList(value: string): boolean {
   return LIST_ITEM_REGEX.test(value);
@@ -28,10 +29,61 @@ function getLevel(value: string): number {
   return 0;
 }
 
+const cache = new Map<number, RegExp>();
+
+function getIndentRegex(indent: number): RegExp {
+  if (cache.has(indent)) {
+    return cache.get(indent) as RegExp;
+  }
+
+  const tabs = Math.ceil(indent / 4);
+  const regex = new RegExp(`^(?: {${indent}}|\t{${tabs}})`);
+
+  cache.set(indent, regex);
+
+  return regex;
+}
+
+function getLines(text: string, indent: number): { markdownSlice: string; position: number } {
+  const regex = /^(.*)(?:\n|\r\n?|$)/gm;
+  const lines: string[] = [];
+
+  let prevEmptyLine = false;
+  let match;
+  let position = 0;
+  while ((match = regex.exec(text))) {
+    const line = match[0];
+
+    if (line === '') {
+      break;
+    }
+
+    const hasIndentation = getIndentRegex(indent).test(line);
+
+    // Break current list parsing when previous line is an empty line and current line does not match the indentation
+    if (prevEmptyLine && line !== '' && !hasIndentation) {
+      break;
+    }
+
+    // Break current list parsing when next line a list item on the same level as the current list
+    if (!hasIndentation && isList(line)) {
+      break;
+    }
+
+    prevEmptyLine = EMPTY_LINE_REGEX.test(line);
+
+    position += line.length;
+
+    lines.push(hasIndentation ? line.slice(indent) : line);
+  }
+
+  return { markdownSlice: lines.join(''), position };
+}
+
 export const listRule: Rule<MarkdownListNode> = {
-  type: 'inline-block',
+  type: 'block',
   name: 'list',
-  ruleStartChar: ['*', '-', '+', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+  // ruleStartChar: ['*', '-', '+', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
   test(state) {
     if (state.position > state.lineStart + state.indent) {
       return false;
@@ -91,16 +143,26 @@ export const listRule: Rule<MarkdownListNode> = {
         }
 
         if (state.charAt(0) === '\n' && (state.charAt(1) === '\n' || state.charAt(1) === '')) {
+          // Only break of we find a matching rule?
           break;
         }
 
         parser.skip(bullet.length + (lineStart - state.position));
 
+        const indent = state.position - state.lineStart;
+        const { markdownSlice, position } = getLines(state.src.slice(state.position), indent);
+
+        parser.skip(position);
+
+        if (state.charAt(-1) === '\n') {
+          parser.skip(-1);
+        }
+
+        parser.parseIndentation();
+
         node.children.push({
           type: 'listItem',
-          children: parser.parseInline(() => {
-            return state.charAt(0) === '\n' && state.charAt(1) === '\n';
-          }),
+          children: parser.parse(markdownSlice),
         });
       }
 

--- a/src/tests/heading.test.ts
+++ b/src/tests/heading.test.ts
@@ -67,4 +67,20 @@ describe('parse.heading', () => {
       },
     ]);
   });
+
+  it('should not parse invalid heading', () => {
+    const ast = parseMarkdown('#qwqweqe');
+
+    expect(ast).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            value: '#qwqweqe',
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/tests/lineBreak.test.ts
+++ b/src/tests/lineBreak.test.ts
@@ -1,0 +1,49 @@
+import { parseMarkdown } from '../parseMarkdown';
+
+describe('parse.lineBreak', () => {
+  it('should parse line break', () => {
+    const ast = parseMarkdown('Line 1\nLine 2');
+
+    expect(ast).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            value: 'Line 1',
+          },
+          {
+            type: 'lineBreak',
+          },
+          {
+            type: 'text',
+            value: 'Line 2',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should parse single backslash on the end of a line as a line break', () => {
+    const ast = parseMarkdown('Line 1\\\nLine 2');
+
+    expect(ast).toEqual([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'text',
+            value: 'Line 1',
+          },
+          {
+            type: 'lineBreak',
+          },
+          {
+            type: 'text',
+            value: 'Line 2',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/tests/list.test.ts
+++ b/src/tests/list.test.ts
@@ -97,21 +97,31 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Item 1',
-              },
-            ],
-          },
-          {
-            type: 'list',
-            ordered: false,
-            children: [
-              {
-                type: 'listItem',
+                type: 'paragraph',
                 children: [
                   {
                     type: 'text',
-                    value: 'Item 2',
+                    value: 'Item 1',
+                  },
+                ],
+              },
+              {
+                type: 'list',
+                ordered: false,
+                children: [
+                  {
+                    type: 'listItem',
+                    children: [
+                      {
+                        type: 'paragraph',
+                        children: [
+                          {
+                            type: 'text',
+                            value: 'Item 2',
+                          },
+                        ],
+                      },
+                    ],
                   },
                 ],
               },
@@ -121,8 +131,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Item 3',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Item 3',
+                  },
+                ],
               },
             ],
           },

--- a/src/tests/list.test.ts
+++ b/src/tests/list.test.ts
@@ -13,8 +13,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Item 1',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Item 1',
+                  },
+                ],
               },
             ],
           },
@@ -22,8 +27,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Item 2',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Item 2',
+                  },
+                ],
               },
             ],
           },
@@ -45,8 +55,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Item 1',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Item 1',
+                  },
+                ],
               },
             ],
           },
@@ -54,8 +69,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Item 2',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Item 2',
+                  },
+                ],
               },
             ],
           },
@@ -64,7 +84,7 @@ describe('parse.list', () => {
     ]);
   });
 
-  it('should parse multilevel unordered list', () => {
+  it.only('should parse multilevel unordered list', () => {
     // Note the tab character before the second list item
     const ast = parseMarkdown('* Item 1\n\t* Item 2\n* Item 3');
 
@@ -122,8 +142,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'text',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'text',
+                  },
+                ],
               },
             ],
           },
@@ -144,8 +169,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Item 1',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Item 1',
+                  },
+                ],
               },
             ],
           },
@@ -164,8 +194,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Red: 0% - 20%',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Red: 0% - 20%',
+                  },
+                ],
               },
             ],
           },
@@ -173,8 +208,13 @@ describe('parse.list', () => {
             type: 'listItem',
             children: [
               {
-                type: 'text',
-                value: 'Amber: 21% - 35%',
+                type: 'paragraph',
+                children: [
+                  {
+                    type: 'text',
+                    value: 'Amber: 21% - 35%',
+                  },
+                ],
               },
             ],
           },

--- a/src/todos
+++ b/src/todos
@@ -1,3 +1,4 @@
+- Documentation
 - Checkboxes
 - Example rule for :emoji: and :emoji: :emoji: https://github.com/muan/emojilib
 - Check encoding
@@ -7,10 +8,3 @@
 - For security reasons, the Unicode character U+0000 must be replaced with the REPLACEMENT CHARACTER (U+FFFD).
 - https://spec.commonmark.org/0.30/
 - Inline matchers like bold and emphasis should only work when the start if before a non whitespace character and the end is after a non whitespace character.
-
-We could first pasrse all "sections"? And then parse every section
-Would make it easier for tags not to break the whole document.
-
-Bla \*sdsdf kjasd agad d.
-
-Next paragraph \*yo.


### PR DESCRIPTION
The next example is now correctly parsed

```text
1.  List item one.

    List item one continued with a second paragraph followed by an
    Indented block.

        $ ls *.sh
        $ mv *.sh ~/tmp

    List item continued with a third paragraph.

2.  List item two continued with an open block.

    This paragraph is part of the preceding list item.

    1. This list is nested and does not require explicit item continuation.

       This paragraph is part of the preceding list item.

    2. List item b.

    This paragraph belongs to item two of the outer list.
```