### PR TITLE
Fixed issue with input where multiple lists are specified on the same line.

### DIFF
--- a/.changeset/moody-lobsters-tan.md
+++ b/.changeset/moody-lobsters-tan.md
@@ -1,0 +1,6 @@
+---
+'@md-parser/parser': patch
+---
+
+Fixed regression when parsing lists.
+Input "12. 12. 1212" caused infinite loop.

--- a/src/tests/list.test.ts
+++ b/src/tests/list.test.ts
@@ -238,7 +238,6 @@ describe('parse.list', () => {
     ]);
   });
 
-  // TODO - Fix this test
   it('should parse list items correctly that contains a horizontal rule', () => {
     expect(parseMarkdown('* foo\n\n---\n\n* bar')).toEqual([
       {
@@ -277,6 +276,44 @@ describe('parse.list', () => {
                   {
                     type: 'text',
                     value: 'bar',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should parse single line lists', () => {
+    expect(parseMarkdown('23. 10. 2000')).toEqual([
+      {
+        type: 'list',
+        ordered: true,
+        start: 23,
+        children: [
+          {
+            type: 'listItem',
+            children: [
+              {
+                type: 'list',
+                ordered: true,
+                start: 10,
+                children: [
+                  {
+                    type: 'listItem',
+                    children: [
+                      {
+                        type: 'paragraph',
+                        children: [
+                          {
+                            type: 'text',
+                            value: '2000',
+                          },
+                        ],
+                      },
+                    ],
                   },
                 ],
               },


### PR DESCRIPTION
Fixed issue with input where multiple lists are specified on the same line.

Fixes loop caused by the following input:
`"12. 13. 1234"`